### PR TITLE
Improve usage of windows and popover behavior

### DIFF
--- a/Source/ViewerController.swift
+++ b/Source/ViewerController.swift
@@ -294,8 +294,9 @@ extension ViewerController {
             presentedView.center = viewerItemController.imageView.center
         }
 
-        self.view.addSubview(self.overlayView)
-        self.view.addSubview(presentedView)
+        let window = self.applicationWindow()
+        window.addSubview(self.overlayView)
+        window.addSubview(presentedView)
         self.shouldUseLightStatusBar = false
 
         UIView.animateWithDuration(0.30, animations: {

--- a/Source/ViewerController.swift
+++ b/Source/ViewerController.swift
@@ -230,16 +230,14 @@ extension ViewerController {
         let image = viewerItem.placeholder
         selectedCell.alpha = 0
 
-        let window = self.applicationWindow()
-
         let presentedView = self.presentedViewCopy()
-        presentedView.frame = window.convertRect(selectedCell.frame, fromView: self.collectionView)
+        presentedView.frame = self.view.convertRect(selectedCell.frame, fromView: self.collectionView)
         presentedView.image = image
 
-        window.addSubview(self.overlayView)
-        window.addSubview(presentedView)
-        window.addSubview(self.headerView)
-        window.addSubview(self.footerView)
+        self.view.addSubview(self.overlayView)
+        self.view.addSubview(presentedView)
+        self.view.addSubview(self.headerView)
+        self.view.addSubview(self.footerView)
 
         let centeredImageFrame = image.centeredFrame()
         UIView.animateWithDuration(0.25, animations: {
@@ -296,9 +294,8 @@ extension ViewerController {
             presentedView.center = viewerItemController.imageView.center
         }
 
-        let window = self.applicationWindow()
-        window.addSubview(self.overlayView)
-        window.addSubview(presentedView)
+        self.view.addSubview(self.overlayView)
+        self.view.addSubview(presentedView)
         self.shouldUseLightStatusBar = false
 
         UIView.animateWithDuration(0.30, animations: {
@@ -307,7 +304,7 @@ extension ViewerController {
             #if os(iOS)
                 self.setNeedsStatusBarAppearanceUpdate()
             #endif
-            presentedView.frame = window.convertRect(selectedCellFrame, fromView: self.collectionView)
+            presentedView.frame = self.view.convertRect(selectedCellFrame, fromView: self.collectionView)
             }) { completed in
                 if let existingCell = self.collectionView.cellForItemAtIndexPath(viewerItemController.indexPath!) {
                     existingCell.alpha = 1

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -3,6 +3,7 @@ import UIKit
 class RemoteCollectionController: UICollectionViewController {
     var photos = Photo.constructRemoteElements()
     var viewerController: ViewerController?
+    var optionsController: OptionsController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -17,9 +18,9 @@ class RemoteCollectionController: UICollectionViewController {
         NSNotificationCenter.defaultCenter().addObserverForName(HeaderView.MenuNotificationName, object: nil, queue: nil) { notification in
             let button = notification.object as! UIButton
             let rect = CGRect(x: 0, y: 0, width: 50, height: 50)
-            let optionsController = OptionsController(sourceView: button, sourceRect: rect)
-            optionsController.controllerDelegate = self
-            self.viewerController?.presentViewController(optionsController, animated: true, completion: nil)
+            self.optionsController = OptionsController(sourceView: button, sourceRect: rect)
+            self.optionsController!.controllerDelegate = self
+            self.viewerController?.presentViewController(self.optionsController!, animated: true, completion: nil)
         }
 
         NSNotificationCenter.defaultCenter().addObserverForName(FooterView.FavoriteNotificationName, object: nil, queue: nil) { notification in
@@ -80,6 +81,8 @@ extension RemoteCollectionController: ViewerControllerDataSource {
 
 extension RemoteCollectionController: OptionsControllerDelegate {
     func optionsController(optionsController: OptionsController, didSelectOption option: String) {
-        self.viewerController?.dismissViewControllerAnimated(true, completion: nil)
+        self.optionsController?.dismissViewControllerAnimated(true) {
+            self.viewerController?.dismiss(nil)
+        }
     }
 }


### PR DESCRIPTION
Window is only needed when faking dismiss animation. Main reason for this change is that using popovers in Viewer gets super difficult since buttons are on top of window, hence, popover is bellow buttons.
