### PR TITLE
Bugfix: Pinch to zoom makes images black

### DIFF
--- a/Source/ViewerItemController.swift
+++ b/Source/ViewerItemController.swift
@@ -113,10 +113,10 @@ class ViewerItemController: UIViewController {
     }
 
     func maxZoomScale() -> CGFloat {
-        guard let image = self.imageView.image else { return 0 }
+        guard let image = self.imageView.image else { return 1 }
 
-        var widthFactor = CGFloat(0.0)
-        var heightFactor = CGFloat(0.0)
+        var widthFactor = CGFloat(1.0)
+        var heightFactor = CGFloat(1.0)
         if image.size.width > self.view.bounds.width {
             widthFactor = image.size.width / self.view.bounds.width
         }

--- a/Source/ViewerItemController.swift
+++ b/Source/ViewerItemController.swift
@@ -191,6 +191,7 @@ class ViewerItemController: UIViewController {
             viewerItem.media({ image, error in
                 if let image = image {
                     self.imageView.image = image
+                    self.scrollView.maximumZoomScale = self.maxZoomScale()
                 }
             })
         }


### PR DESCRIPTION
Pinch to zoom images smaller than the screen size makes the image disappear. This happens because calculating maxZoomScale is failing. The initial widthFactor and heightFactor should be 1.0 instead of 0.0 to prevent getting scaleFactor of 0.0.

Also when updating the image, the maxZoomScale must be recalculated. (when loading large image instead of placeholder). I added an update to this in the didFocus() that worked, but maybe you know a better place :)
