### PR TITLE
Rename

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		143803401C2452A1003CA252 /* UIImage+CenteredFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803361C2452A1003CA252 /* UIImage+CenteredFrame.swift */; };
 		143803421C2452A1003CA252 /* UIViewController+Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803371C2452A1003CA252 /* UIViewController+Window.swift */; };
 		143803441C2452A1003CA252 /* ViewerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803381C2452A1003CA252 /* ViewerController.swift */; };
-		143803461C2452A1003CA252 /* ViewerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803391C2452A1003CA252 /* ViewerItem.swift */; };
-		143803481C2452A1003CA252 /* ViewerItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1438033A1C2452A1003CA252 /* ViewerItemController.swift */; };
+		143803461C2452A1003CA252 /* Viewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803391C2452A1003CA252 /* Viewable.swift */; };
+		143803481C2452A1003CA252 /* ViewableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1438033A1C2452A1003CA252 /* ViewableController.swift */; };
 		143B5C3B1C0EED51000B6A18 /* PhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143B5C3A1C0EED51000B6A18 /* PhotoCell.swift */; };
 		143B5C3F1C0EF76E000B6A18 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143B5C3E1C0EF76E000B6A18 /* Photo.swift */; };
 		1459C2211CB694690007E498 /* pause.png in Resources */ = {isa = PBXBuildFile; fileRef = 1459C2181CB694690007E498 /* pause.png */; };
@@ -29,8 +29,8 @@
 		147EE8571C92F10300A7B449 /* NSIndexPath+Contiguous.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803351C2452A1003CA252 /* NSIndexPath+Contiguous.swift */; };
 		147EE8581C92F10700A7B449 /* UIViewController+Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803371C2452A1003CA252 /* UIViewController+Window.swift */; };
 		147EE8591C92F10A00A7B449 /* ViewerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803381C2452A1003CA252 /* ViewerController.swift */; };
-		147EE85A1C92F10C00A7B449 /* ViewerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803391C2452A1003CA252 /* ViewerItem.swift */; };
-		147EE85B1C92F10E00A7B449 /* ViewerItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1438033A1C2452A1003CA252 /* ViewerItemController.swift */; };
+		147EE85A1C92F10C00A7B449 /* Viewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143803391C2452A1003CA252 /* Viewable.swift */; };
+		147EE85B1C92F10E00A7B449 /* ViewableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1438033A1C2452A1003CA252 /* ViewableController.swift */; };
 		14A139B41AEFC72B00AD732F /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A139B31AEFC72B00AD732F /* Tests.swift */; };
 		14A4EDBC1C216E3F00411FC6 /* PopupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A4EDBB1C216E3F00411FC6 /* PopupController.swift */; };
 		14AE4D5D1C18834500EEC4D9 /* 3.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 14AE4D5C1C18834500EEC4D9 /* 3.jpg */; };
@@ -63,8 +63,8 @@
 		143803361C2452A1003CA252 /* UIImage+CenteredFrame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+CenteredFrame.swift"; sourceTree = "<group>"; };
 		143803371C2452A1003CA252 /* UIViewController+Window.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Window.swift"; sourceTree = "<group>"; };
 		143803381C2452A1003CA252 /* ViewerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewerController.swift; sourceTree = "<group>"; };
-		143803391C2452A1003CA252 /* ViewerItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewerItem.swift; sourceTree = "<group>"; };
-		1438033A1C2452A1003CA252 /* ViewerItemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewerItemController.swift; sourceTree = "<group>"; };
+		143803391C2452A1003CA252 /* Viewable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Viewable.swift; sourceTree = "<group>"; };
+		1438033A1C2452A1003CA252 /* ViewableController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewableController.swift; sourceTree = "<group>"; };
 		143B5C3A1C0EED51000B6A18 /* PhotoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoCell.swift; sourceTree = "<group>"; };
 		143B5C3E1C0EF76E000B6A18 /* Photo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
 		1459C2181CB694690007E498 /* pause.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = pause.png; sourceTree = "<group>"; };
@@ -194,8 +194,8 @@
 				143803361C2452A1003CA252 /* UIImage+CenteredFrame.swift */,
 				143803371C2452A1003CA252 /* UIViewController+Window.swift */,
 				143803381C2452A1003CA252 /* ViewerController.swift */,
-				143803391C2452A1003CA252 /* ViewerItem.swift */,
-				1438033A1C2452A1003CA252 /* ViewerItemController.swift */,
+				143803391C2452A1003CA252 /* Viewable.swift */,
+				1438033A1C2452A1003CA252 /* ViewableController.swift */,
 				E6D592821D226528006EF238 /* VideoProgressView.swift */,
 				14EC47B71C58F6BC0028A0CD /* VideoView.swift */,
 				14C327B71CBE69F800CC0F98 /* PaginatedScrollView.swift */,
@@ -377,11 +377,11 @@
 				E6D592831D226528006EF238 /* VideoProgressView.swift in Sources */,
 				14C327B81CBE69F800CC0F98 /* PaginatedScrollView.swift in Sources */,
 				147EE8591C92F10A00A7B449 /* ViewerController.swift in Sources */,
-				147EE85B1C92F10E00A7B449 /* ViewerItemController.swift in Sources */,
+				147EE85B1C92F10E00A7B449 /* ViewableController.swift in Sources */,
 				147EE8571C92F10300A7B449 /* NSIndexPath+Contiguous.swift in Sources */,
 				147EE8561C92F0FF00A7B449 /* UIImage+CenteredFrame.swift in Sources */,
 				14EC47B81C58F6BC0028A0CD /* VideoView.swift in Sources */,
-				147EE85A1C92F10C00A7B449 /* ViewerItem.swift in Sources */,
+				147EE85A1C92F10C00A7B449 /* Viewable.swift in Sources */,
 				14A139B41AEFC72B00AD732F /* Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -390,8 +390,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				143803481C2452A1003CA252 /* ViewerItemController.swift in Sources */,
-				143803461C2452A1003CA252 /* ViewerItem.swift in Sources */,
+				143803481C2452A1003CA252 /* ViewableController.swift in Sources */,
+				143803461C2452A1003CA252 /* Viewable.swift in Sources */,
 				143803441C2452A1003CA252 /* ViewerController.swift in Sources */,
 				143803421C2452A1003CA252 /* UIViewController+Window.swift in Sources */,
 				143B5C3F1C0EF76E000B6A18 /* Photo.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ override func collectionView(collectionView: UICollectionView, didSelectItemAtIn
 }
 
 extension CollectionController: ViewerControllerDataSource {
-    func viewerController(viewerController: ViewerController, itemAtIndexPath indexPath: NSIndexPath) -> ViewerItem {
+    func viewerController(viewerController: ViewerController, itemAtIndexPath indexPath: NSIndexPath) -> Viewable {
         return self.photos[indexPath.row]
     }
 }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ override func collectionView(collectionView: UICollectionView, didSelectItemAtIn
     let footerView = FooterView()
     footerView.viewDelegate = self
     self.viewerController?.footerView = footerView
-    viewerController.controllerDataSource = self
+    viewerController.dataSource = self
     self.presentViewController(viewerController, animated: false, completion: nil)
 }
 

--- a/Source/VideoView.swift
+++ b/Source/VideoView.swift
@@ -121,8 +121,8 @@ class VideoView: UIView {
         }
     }
 
-    func prepare(using viewerItem: ViewerItem, completion: @escaping (Void) -> Void) {
-        self.addPlayer(using: viewerItem) {
+    func prepare(using viewable: Viewable, completion: @escaping (Void) -> Void) {
+        self.addPlayer(using: viewable) {
             if self.shouldRegisterForStatusNotifications {
                 guard let player = self.playerLayer.player else { fatalError("No player item was found") }
 
@@ -140,9 +140,9 @@ class VideoView: UIView {
         }
     }
 
-    func addPlayer(using viewerItem: ViewerItem, completion: @escaping (Void) -> Void) {
+    func addPlayer(using viewable: Viewable, completion: @escaping (Void) -> Void) {
         DispatchQueue.global(qos: .background).async {
-            if let assetID = viewerItem.assetID {
+            if let assetID = viewable.assetID {
                 #if os(iOS)
                     let result = PHAsset.fetchAssets(withLocalIdentifiers: [assetID], options: nil)
                     guard let asset = result.firstObject else { fatalError("Couldn't get asset for id: \(assetID)") }
@@ -181,7 +181,7 @@ class VideoView: UIView {
                         }
                     }
                 #endif
-            } else if let url = viewerItem.url {
+            } else if let url = viewable.url {
                 let streamingURL = URL(string: url)!
                 self.playerLayer.player = AVPlayer(url: streamingURL)
                 self.playerLayer.isHidden = true

--- a/Source/Viewable.swift
+++ b/Source/Viewable.swift
@@ -1,12 +1,12 @@
 import UIKit
 
-public enum ViewerItemType: String {
+public enum ViewableType: String {
     case image
     case video
 }
 
-public protocol ViewerItem {
-    var type: ViewerItemType { get }
+public protocol Viewable {
+    var type: ViewableType { get }
     var id: String { get }
     var assetID: String? { get }
     var url: String? { get }

--- a/Source/ViewableController.swift
+++ b/Source/ViewableController.swift
@@ -6,21 +6,21 @@ import AVKit
     import Photos
 #endif
 
-protocol ViewerItemControllerDelegate: class {
-    func viewerItemControllerDidTapItem(_ viewerItemController: ViewerItemController, completion: (() -> Void)?)
+protocol ViewableControllerDelegate: class {
+    func viewableControllerDidTapItem(_ viewableController: ViewableController, completion: (() -> Void)?)
 }
 
-protocol ViewerItemControllerDataSource: class {
-    func isViewerItemControllerOverlayHidden(_ viewerItemController: ViewerItemController) -> Bool
-    func viewerItemControllerIsFocused(_ viewerItemController: ViewerItemController) -> Bool
-    func viewerItemControllerShouldAutoplayVideo(_ viewerItemController: ViewerItemController) -> Bool
+protocol ViewableControllerDataSource: class {
+    func isViewableControllerOverlayHidden(_ viewableController: ViewableController) -> Bool
+    func viewableControllerIsFocused(_ viewableController: ViewableController) -> Bool
+    func viewableControllerShouldAutoplayVideo(_ viewableController: ViewableController) -> Bool
 }
 
-class ViewerItemController: UIViewController {
+class ViewableController: UIViewController {
     private static let FooterViewHeight = CGFloat(50.0)
 
-    weak var controllerDelegate: ViewerItemControllerDelegate?
-    weak var controllerDataSource: ViewerItemControllerDataSource?
+    weak var controllerDelegate: ViewableControllerDelegate?
+    weak var controllerDataSource: ViewableControllerDataSource?
 
     var indexPath: IndexPath?
 
@@ -61,7 +61,7 @@ class ViewerItemController: UIViewController {
         let image = UIImage(named: "play")!
         button.setImage(image, for: UIControlState())
         button.alpha = 0
-        button.addTarget(self, action: #selector(ViewerItemController.playAction), for: .touchUpInside)
+        button.addTarget(self, action: #selector(ViewableController.playAction), for: .touchUpInside)
 
         return button
     }()
@@ -71,7 +71,7 @@ class ViewerItemController: UIViewController {
         let image = UIImage(named: "repeat")!
         button.setImage(image, for: UIControlState())
         button.alpha = 0
-        button.addTarget(self, action: #selector(ViewerItemController.repeatAction), for: .touchUpInside)
+        button.addTarget(self, action: #selector(ViewableController.repeatAction), for: .touchUpInside)
 
         return button
     }()
@@ -81,7 +81,7 @@ class ViewerItemController: UIViewController {
         let image = UIImage(named: "pause")!
         button.setImage(image, for: UIControlState())
         button.alpha = 0
-        button.addTarget(self, action: #selector(ViewerItemController.pauseAction), for: .touchUpInside)
+        button.addTarget(self, action: #selector(ViewableController.pauseAction), for: .touchUpInside)
 
         return button
     }()
@@ -94,20 +94,20 @@ class ViewerItemController: UIViewController {
     }()
 
     var changed = false
-    var viewerItem: ViewerItem? {
+    var viewable: Viewable? {
         willSet {
-            if self.viewerItem?.id != newValue?.id {
+            if self.viewable?.id != newValue?.id {
                 self.changed = true
             }
         }
 
         didSet {
-            guard let viewerItem = self.viewerItem else { return }
+            guard let viewable = self.viewable else { return }
 
             if self.changed {
-                self.videoView.image = viewerItem.placeholder
-                self.imageView.image = viewerItem.placeholder
-                self.videoView.frame = viewerItem.placeholder.centeredFrame()
+                self.videoView.image = viewable.placeholder
+                self.imageView.image = viewable.placeholder
+                self.videoView.frame = viewable.placeholder.centeredFrame()
 
                 self.changed = false
             }
@@ -145,7 +145,7 @@ class ViewerItemController: UIViewController {
         self.view.addSubview(self.pauseButton)
         self.view.addSubview(self.videoProgressView)
 
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(ViewerItemController.tapAction))
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(ViewableController.tapAction))
         self.view.addGestureRecognizer(tapRecognizer)
     }
 
@@ -156,17 +156,17 @@ class ViewerItemController: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        guard let viewerItem = self.viewerItem else { return }
+        guard let viewable = self.viewable else { return }
 
-        let isFocused = self.controllerDataSource?.viewerItemControllerIsFocused(self)
-        if viewerItem.type == .video || isFocused == false {
+        let isFocused = self.controllerDataSource?.viewableControllerIsFocused(self)
+        if viewable.type == .video || isFocused == false {
             self.view.backgroundColor = .clear
             self.zoomingScrollView.isHidden = true
         }
         coordinator.animate(alongsideTransition: { context in
 
             }) { completionContext in
-                if viewerItem.type == .video || isFocused == false  {
+                if viewable.type == .video || isFocused == false  {
                     self.view.backgroundColor = .black
                     self.zoomingScrollView.isHidden = false
                 }
@@ -181,7 +181,7 @@ class ViewerItemController: UIViewController {
             }) 
         }
 
-        self.controllerDelegate?.viewerItemControllerDidTapItem(self, completion: nil)
+        self.controllerDelegate?.viewableControllerDidTapItem(self, completion: nil)
     }
 
     override func viewWillLayoutSubviews() {
@@ -194,13 +194,13 @@ class ViewerItemController: UIViewController {
         self.repeatButton.frame = CGRect(x: (self.view.frame.size.width - buttonWidth) / 2, y: (self.view.frame.size.height - buttonHeight) / 2, width: buttonHeight, height: buttonHeight)
         self.pauseButton.frame = CGRect(x: (self.view.frame.size.width - buttonWidth) / 2, y: (self.view.frame.size.height - buttonHeight) / 2, width: buttonHeight, height: buttonHeight)
 
-        self.videoProgressView.frame = CGRect(x: 0, y: (self.view.frame.height - ViewerItemController.FooterViewHeight - VideoProgressView.Height), width: self.view.frame.width, height: VideoProgressView.Height)
+        self.videoProgressView.frame = CGRect(x: 0, y: (self.view.frame.height - ViewableController.FooterViewHeight - VideoProgressView.Height), width: self.view.frame.width, height: VideoProgressView.Height)
     }
 
     func willDismiss() {
-        guard let viewerItem = self.viewerItem else { return }
+        guard let viewable = self.viewable else { return }
 
-        if viewerItem.type == .video {
+        if viewable.type == .video {
             self.videoView.stopPlayerAndRemoveObserverIfNecessary()
             self.videoView.stop()
             self.resetButtonStates()
@@ -210,21 +210,21 @@ class ViewerItemController: UIViewController {
     }
 
     func didFocus() {
-        guard let viewerItem = self.viewerItem else { return }
+        guard let viewable = self.viewable else { return }
 
-        switch viewerItem.type {
+        switch viewable.type {
         case .image:
-            viewerItem.media { image, error in
+            viewable.media { image, error in
                 if let image = image {
                     self.imageView.image = image
                     self.zoomingScrollView.maximumZoomScale = self.maxZoomScale()
                 }
             }
         case .video:
-            self.videoView.prepare(using: viewerItem) {
-                NotificationCenter.default.addObserver(self, selector: #selector(ViewerItemController.videoFinishedPlaying), name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: nil)
+            self.videoView.prepare(using: viewable) {
+                NotificationCenter.default.addObserver(self, selector: #selector(ViewableController.videoFinishedPlaying), name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: nil)
 
-                let autoplayVideo = self.controllerDataSource?.viewerItemControllerShouldAutoplayVideo(self) ?? false
+                let autoplayVideo = self.controllerDataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
                 if autoplayVideo {
                     self.videoView.play()
                 } else {
@@ -270,7 +270,7 @@ class ViewerItemController: UIViewController {
     func repeatAction() {
         self.repeatButton.alpha = 0
 
-        let overlayIsHidden = self.controllerDataSource?.isViewerItemControllerOverlayHidden(self) ?? false
+        let overlayIsHidden = self.controllerDataSource?.isViewableControllerOverlayHidden(self) ?? false
         if overlayIsHidden {
             self.videoProgressView.alpha = 0
         } else {
@@ -282,9 +282,9 @@ class ViewerItemController: UIViewController {
     }
 
     func requestToHideOverlayIfNeeded() {
-        let overlayIsHidden = self.controllerDataSource?.isViewerItemControllerOverlayHidden(self) ?? false
+        let overlayIsHidden = self.controllerDataSource?.isViewableControllerOverlayHidden(self) ?? false
         if overlayIsHidden == false {
-            self.controllerDelegate?.viewerItemControllerDidTapItem(self, completion: nil)
+            self.controllerDelegate?.viewableControllerDidTapItem(self, completion: nil)
         }
     }
 
@@ -324,9 +324,9 @@ class ViewerItemController: UIViewController {
     }
 }
 
-extension ViewerItemController: UIScrollViewDelegate {
+extension ViewableController: UIScrollViewDelegate {
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        if self.viewerItem?.type == .image {
+        if self.viewable?.type == .image {
             return self.imageView
         } else {
             return nil
@@ -334,7 +334,7 @@ extension ViewerItemController: UIScrollViewDelegate {
     }
 }
 
-extension ViewerItemController: VideoViewDelegate {
+extension ViewableController: VideoViewDelegate {
     func videoViewDidStartPlaying(_ videoView: VideoView) {
         self.requestToHideOverlayIfNeeded()
     }

--- a/Source/ViewableController.swift
+++ b/Source/ViewableController.swift
@@ -19,8 +19,8 @@ protocol ViewableControllerDataSource: class {
 class ViewableController: UIViewController {
     private static let FooterViewHeight = CGFloat(50.0)
 
-    weak var controllerDelegate: ViewableControllerDelegate?
-    weak var controllerDataSource: ViewableControllerDataSource?
+    weak var delegate: ViewableControllerDelegate?
+    weak var dataSource: ViewableControllerDataSource?
 
     var indexPath: IndexPath?
 
@@ -158,7 +158,7 @@ class ViewableController: UIViewController {
 
         guard let viewable = self.viewable else { return }
 
-        let isFocused = self.controllerDataSource?.viewableControllerIsFocused(self)
+        let isFocused = self.dataSource?.viewableControllerIsFocused(self)
         if viewable.type == .video || isFocused == false {
             self.view.backgroundColor = .clear
             self.zoomingScrollView.isHidden = true
@@ -181,7 +181,7 @@ class ViewableController: UIViewController {
             }) 
         }
 
-        self.controllerDelegate?.viewableControllerDidTapItem(self, completion: nil)
+        self.delegate?.viewableControllerDidTapItem(self, completion: nil)
     }
 
     override func viewWillLayoutSubviews() {
@@ -224,7 +224,7 @@ class ViewableController: UIViewController {
             self.videoView.prepare(using: viewable) {
                 NotificationCenter.default.addObserver(self, selector: #selector(ViewableController.videoFinishedPlaying), name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: nil)
 
-                let autoplayVideo = self.controllerDataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
+                let autoplayVideo = self.dataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
                 if autoplayVideo {
                     self.videoView.play()
                 } else {
@@ -270,7 +270,7 @@ class ViewableController: UIViewController {
     func repeatAction() {
         self.repeatButton.alpha = 0
 
-        let overlayIsHidden = self.controllerDataSource?.isViewableControllerOverlayHidden(self) ?? false
+        let overlayIsHidden = self.dataSource?.isViewableControllerOverlayHidden(self) ?? false
         if overlayIsHidden {
             self.videoProgressView.alpha = 0
         } else {
@@ -282,9 +282,9 @@ class ViewableController: UIViewController {
     }
 
     func requestToHideOverlayIfNeeded() {
-        let overlayIsHidden = self.controllerDataSource?.isViewableControllerOverlayHidden(self) ?? false
+        let overlayIsHidden = self.dataSource?.isViewableControllerOverlayHidden(self) ?? false
         if overlayIsHidden == false {
-            self.controllerDelegate?.viewableControllerDidTapItem(self, completion: nil)
+            self.delegate?.viewableControllerDidTapItem(self, completion: nil)
         }
     }
 

--- a/Source/ViewerController.swift
+++ b/Source/ViewerController.swift
@@ -9,7 +9,7 @@ import CoreData
 
 public protocol ViewerControllerDataSource: class {
     func numberOfItemsInViewerController(_ viewerController: ViewerController) -> Int
-    func viewerController(_ viewerController: ViewerController, itemAtIndexPath indexPath: IndexPath) -> ViewerItem
+    func viewerController(_ viewerController: ViewerController, itemAtIndexPath indexPath: IndexPath) -> Viewable
 }
 
 public protocol ViewerControllerDelegate: class {
@@ -57,9 +57,9 @@ public class ViewerController: UIViewController {
     public var autoplayVideos: Bool = false
 
     /**
-     Cache for the reused ViewerItemControllers
+     Cache for the reused ViewableControllers
      */
-    fileprivate let viewerItemControllerCache = NSCache<NSString, ViewerItemController>()
+    fileprivate let viewableControllerCache = NSCache<NSString, ViewableController>()
 
     /**
      Temporary variable used to present the initial controller on viewDidAppear
@@ -183,28 +183,28 @@ extension ViewerController {
         return presentedView
     }
 
-    fileprivate func findOrCreateViewerItemController(_ indexPath: IndexPath) -> ViewerItemController {
-        let viewerItem = self.controllerDataSource!.viewerController(self, itemAtIndexPath: indexPath)
-        var viewerItemController: ViewerItemController
+    fileprivate func findOrCreateViewableController(_ indexPath: IndexPath) -> ViewableController {
+        let viewable = self.controllerDataSource!.viewerController(self, itemAtIndexPath: indexPath)
+        var viewableController: ViewableController
 
-        if let cachedController = self.viewerItemControllerCache.object(forKey: viewerItem.id as NSString) {
-            viewerItemController = cachedController
+        if let cachedController = self.viewableControllerCache.object(forKey: viewable.id as NSString) {
+            viewableController = cachedController
         } else {
-            viewerItemController = ViewerItemController()
-            viewerItemController.controllerDelegate = self
-            viewerItemController.controllerDataSource = self
+            viewableController = ViewableController()
+            viewableController.controllerDelegate = self
+            viewableController.controllerDataSource = self
 
             let gesture = UIPanGestureRecognizer(target: self, action: #selector(ViewerController.panAction(_:)))
             gesture.delegate = self
-            viewerItemController.imageView.addGestureRecognizer(gesture)
+            viewableController.imageView.addGestureRecognizer(gesture)
 
-            self.viewerItemControllerCache.setObject(viewerItemController, forKey: viewerItem.id as NSString)
+            self.viewableControllerCache.setObject(viewableController, forKey: viewable.id as NSString)
         }
 
-        viewerItemController.viewerItem = viewerItem
-        viewerItemController.indexPath = indexPath
+        viewableController.viewable = viewable
+        viewableController.indexPath = indexPath
 
-        return viewerItemController
+        return viewableController
     }
 
     fileprivate func toggleButtons(_ shouldShow: Bool) {
@@ -225,8 +225,8 @@ extension ViewerController {
     fileprivate func present(with indexPath: IndexPath, completion: (() -> Void)?) {
         guard let selectedCell = self.collectionView.cellForItem(at: indexPath) else { fatalError("Data source not implemented") }
 
-        let viewerItem = self.controllerDataSource!.viewerController(self, itemAtIndexPath: indexPath)
-        let image = viewerItem.placeholder
+        let viewable = self.controllerDataSource!.viewerController(self, itemAtIndexPath: indexPath)
+        let image = viewable.placeholder
         selectedCell.alpha = 0
 
         let presentedView = self.presentedViewCopy()
@@ -268,7 +268,7 @@ extension ViewerController {
                 self.overlayView.removeFromSuperview()
                 self.view.backgroundColor = .black
                 self.presented = true
-                let item = self.findOrCreateViewerItemController(indexPath)
+                let item = self.findOrCreateViewableController(indexPath)
                 item.didFocus()
 
                 completion?()
@@ -276,18 +276,18 @@ extension ViewerController {
     }
 
     public func dismiss(_ completion: (() -> Void)?) {
-        let controller = self.findOrCreateViewerItemController(self.currentIndexPath)
+        let controller = self.findOrCreateViewableController(self.currentIndexPath)
         self.dismiss(controller, completion: completion)
     }
 
-    private func dismiss(_ viewerItemController: ViewerItemController, completion: (() -> Void)?) {
-        guard let selectedCellFrame = self.collectionView.layoutAttributesForItem(at: viewerItemController.indexPath!)?.frame else { fatalError() }
+    private func dismiss(_ viewableController: ViewableController, completion: (() -> Void)?) {
+        guard let selectedCellFrame = self.collectionView.layoutAttributesForItem(at: viewableController.indexPath!)?.frame else { fatalError() }
 
-        let viewerItem = self.controllerDataSource!.viewerController(self, itemAtIndexPath: viewerItemController.indexPath!)
-        let image = viewerItem.placeholder
-        viewerItemController.imageView.alpha = 0
-        viewerItemController.view.backgroundColor = .clear
-        viewerItemController.willDismiss()
+        let viewable = self.controllerDataSource!.viewerController(self, itemAtIndexPath: viewableController.indexPath!)
+        let image = viewable.placeholder
+        viewableController.imageView.alpha = 0
+        viewableController.view.backgroundColor = .clear
+        viewableController.willDismiss()
 
         self.view.alpha = 0
         self.fadeButtons(0)
@@ -298,14 +298,14 @@ extension ViewerController {
         #if os(iOS)
             self.setNeedsStatusBarAppearanceUpdate()
         #endif
-        self.overlayView.alpha = self.isDragging ? viewerItemController.view.backgroundColor!.cgColor.alpha : 1.0
+        self.overlayView.alpha = self.isDragging ? viewableController.view.backgroundColor!.cgColor.alpha : 1.0
         self.overlayView.frame = UIScreen.main.bounds
 
         let presentedView = self.presentedViewCopy()
         presentedView.frame = image.centeredFrame()
         presentedView.image = image
         if self.isDragging {
-            presentedView.center = viewerItemController.imageView.center
+            presentedView.center = viewableController.imageView.center
         }
 
         let window = self.applicationWindow()
@@ -321,7 +321,7 @@ extension ViewerController {
             #endif
             presentedView.frame = self.view.convert(selectedCellFrame, from: self.collectionView)
             }, completion: { completed in
-                if let existingCell = self.collectionView.cellForItem(at: viewerItemController.indexPath!) {
+                if let existingCell = self.collectionView.cellForItem(at: viewableController.indexPath!) {
                     existingCell.alpha = 1
                 }
 
@@ -337,7 +337,7 @@ extension ViewerController {
     }
 
     func panAction(_ gesture: UIPanGestureRecognizer) {
-        let controller = self.findOrCreateViewerItemController(self.currentIndexPath)
+        let controller = self.findOrCreateViewableController(self.currentIndexPath)
         let viewHeight = controller.imageView.frame.size.height
         let viewHalfHeight = viewHeight / 2
         var translatedPoint = gesture.translation(in: controller.imageView)
@@ -426,26 +426,26 @@ extension ViewerController {
     }
 }
 
-extension ViewerController: ViewerItemControllerDelegate {
-    func viewerItemControllerDidTapItem(_ viewerItemController: ViewerItemController, completion: (() -> Void)?) {
+extension ViewerController: ViewableControllerDelegate {
+    func viewableControllerDidTapItem(_ viewableController: ViewableController, completion: (() -> Void)?) {
         self.shouldHideStatusBar = !self.shouldHideStatusBar
         self.buttonsAreVisible = !self.buttonsAreVisible
         self.toggleButtons(self.buttonsAreVisible)
     }
 }
 
-extension ViewerController: ViewerItemControllerDataSource {
-    func isViewerItemControllerOverlayHidden(_ viewerItemController: ViewerItemController) -> Bool {
+extension ViewerController: ViewableControllerDataSource {
+    func isViewableControllerOverlayHidden(_ viewableController: ViewableController) -> Bool {
         return !self.buttonsAreVisible
     }
 
-    func viewerItemControllerIsFocused(_ viewerItemController: ViewerItemController) -> Bool {
-        let focusedViewerItemController = self.findOrCreateViewerItemController(self.currentIndexPath)
+    func viewableControllerIsFocused(_ viewableController: ViewableController) -> Bool {
+        let focusedViewableController = self.findOrCreateViewableController(self.currentIndexPath)
 
-        return viewerItemController == focusedViewerItemController
+        return viewableController == focusedViewableController
     }
 
-    func viewerItemControllerShouldAutoplayVideo(_ viewerItemController: ViewerItemController) -> Bool {
+    func viewableControllerShouldAutoplayVideo(_ viewableController: ViewableController) -> Bool {
         return self.autoplayVideos
     }
 }
@@ -472,7 +472,7 @@ extension ViewerController: PaginatedScrollViewDataSource {
     func paginatedScrollView(_ paginatedScrollView: PaginatedScrollView, controllerAtIndex index: Int) -> UIViewController {
         let indexPath = IndexPath.indexPathForIndex(self.collectionView, index: index)!
 
-        return self.findOrCreateViewerItemController(indexPath)
+        return self.findOrCreateViewableController(indexPath)
     }
 }
 
@@ -482,13 +482,13 @@ extension ViewerController: PaginatedScrollViewDelegate {
         self.evaluateCellVisibility(collectionView: self.collectionView, currentIndexPath: self.currentIndexPath, upcomingIndexPath: indexPath)
         self.currentIndexPath = indexPath
         self.controllerDelegate?.viewerController(self, didChangeIndexPath: indexPath)
-        let viewerItemController = self.findOrCreateViewerItemController(indexPath)
-        viewerItemController.didFocus()
+        let viewableController = self.findOrCreateViewableController(indexPath)
+        viewableController.didFocus()
     }
 
     func paginatedScrollView(_ paginatedScrollView: PaginatedScrollView, didMoveFromIndex index: Int) {
         let indexPath = IndexPath.indexPathForIndex(self.collectionView, index: index)!
-        let viewerItemController = self.findOrCreateViewerItemController(indexPath)
-        viewerItemController.willDismiss()
+        let viewableController = self.findOrCreateViewableController(indexPath)
+        viewableController.willDismiss()
     }
 }

--- a/iOS/LocalCollectionController.swift
+++ b/iOS/LocalCollectionController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Photos
 
 class LocalCollectionController: UICollectionViewController {
-    var photos = [ViewerItem]()
+    var photos = [Viewable]()
     var viewerController: ViewerController?
 
     override func viewDidLoad() {
@@ -71,14 +71,14 @@ extension LocalCollectionController: ViewerControllerDataSource {
         return self.photos.count
     }
 
-    func viewerController(_ viewerController: ViewerController, itemAtIndexPath indexPath: IndexPath) -> ViewerItem {
-        var viewerItem = self.photos[indexPath.row]
+    func viewerController(_ viewerController: ViewerController, itemAtIndexPath indexPath: IndexPath) -> Viewable {
+        var viewable = self.photos[indexPath.row]
         if let cell = self.collectionView?.cellForItem(at: indexPath) as? PhotoCell, let placeholder = cell.imageView.image {
-            viewerItem.placeholder = placeholder
+            viewable.placeholder = placeholder
         }
-        self.photos[indexPath.row] = viewerItem
+        self.photos[indexPath.row] = viewable
 
-        return viewerItem
+        return viewable
     }
 }
 

--- a/iOS/LocalCollectionController.swift
+++ b/iOS/LocalCollectionController.swift
@@ -61,7 +61,7 @@ extension LocalCollectionController {
         let footerView = FooterView()
         footerView.viewDelegate = self
         self.viewerController?.footerView = footerView
-        self.viewerController!.controllerDataSource = self
+        self.viewerController!.dataSource = self
         self.present(self.viewerController!, animated: false, completion: nil)
     }
 }

--- a/iOS/Photo.swift
+++ b/iOS/Photo.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Photos
 
-struct Photo: ViewerItem {
+struct Photo: Viewable {
     var placeholder = UIImage()
 
     enum Size {
@@ -9,7 +9,7 @@ struct Photo: ViewerItem {
         case large
     }
 
-    var type: ViewerItemType = .image
+    var type: ViewableType = .image
     var id: String
     var url: String?
     var assetID: String?
@@ -40,11 +40,11 @@ struct Photo: ViewerItem {
         }
     }
 
-    static func constructRemoteElements() -> [[ViewerItem]] {
-        var sections = [[ViewerItem]]()
+    static func constructRemoteElements() -> [[Viewable]] {
+        var sections = [[Viewable]]()
 
         for section in 0..<Photo.NumberOfSections {
-            var elements = [ViewerItem]()
+            var elements = [Viewable]()
             for row in 0..<10 {
                 var photo = Photo(id: "\(section)-\(row)")
 
@@ -79,8 +79,8 @@ struct Photo: ViewerItem {
         return sections
     }
 
-    static func constructLocalElements() -> [ViewerItem] {
-        var elements = [ViewerItem]()
+    static func constructLocalElements() -> [Viewable] {
+        var elements = [Viewable]()
 
         let fetchOptions = PHFetchOptions()
         let authorizationStatus = PHPhotoLibrary.authorizationStatus()

--- a/iOS/PhotoCell.swift
+++ b/iOS/PhotoCell.swift
@@ -33,7 +33,7 @@ class PhotoCell: UICollectionViewCell {
         return view
     }()
 
-    var photo: ViewerItem? {
+    var photo: Viewable? {
         didSet {
             guard let photo = self.photo else {
                 self.imageView.image = nil

--- a/iOS/PopupController.swift
+++ b/iOS/PopupController.swift
@@ -7,7 +7,7 @@ protocol OptionsControllerDelegate: class {
 class OptionsController: UITableViewController {
     static let CellIdentifier = "CellIdentifier"
     static let PopoverSize = CGFloat(179)
-    weak var controllerDelegate: OptionsControllerDelegate?
+    weak var delegate: OptionsControllerDelegate?
     static let RowHeight = CGFloat(60.0)
     fileprivate var options = ["First option", "Second option", "Third option"]
 
@@ -57,6 +57,6 @@ extension OptionsController {
 
     override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let option = self.options[indexPath.row]
-        self.controllerDelegate?.optionsController(optionsController: self, didSelectOption: option)
+        self.delegate?.optionsController(optionsController: self, didSelectOption: option)
     }
 }

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -79,16 +79,16 @@ extension RemoteCollectionController: ViewerControllerDataSource {
         return self.numberOfItems
     }
 
-    func viewerController(_ viewerController: ViewerController, itemAtIndexPath indexPath: IndexPath) -> ViewerItem {
+    func viewerController(_ viewerController: ViewerController, itemAtIndexPath indexPath: IndexPath) -> Viewable {
         var photos = self.sections[indexPath.section]
-        var viewerItem = photos[indexPath.row]
+        var viewable = photos[indexPath.row]
         if let cell = self.collectionView?.cellForItem(at: indexPath) as? PhotoCell, let placeholder = cell.imageView.image {
-            viewerItem.placeholder = placeholder
+            viewable.placeholder = placeholder
         }
-        photos[indexPath.row] = viewerItem
+        photos[indexPath.row] = viewable
         self.sections[indexPath.section] = photos
 
-        return viewerItem
+        return viewable
     }
 }
 

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -69,7 +69,7 @@ extension RemoteCollectionController {
         let footerView = FooterView()
         footerView.viewDelegate = self
         self.viewerController?.footerView = footerView
-        self.viewerController!.controllerDataSource = self
+        self.viewerController!.dataSource = self
         self.present(self.viewerController!, animated: false, completion: nil)
     }
 }
@@ -108,7 +108,7 @@ extension RemoteCollectionController: HeaderViewDelegate {
     func headerView(_ headerView: HeaderView, didPressMenuButton button: UIButton) {
         let rect = CGRect(x: 0, y: 0, width: 50, height: 50)
         self.optionsController = OptionsController(sourceView: button, sourceRect: rect)
-        self.optionsController!.controllerDelegate = self
+        self.optionsController!.delegate = self
         self.viewerController?.present(self.optionsController!, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
- Renamed ViewerItem to Viewable

https://en.oxforddictionaries.com/definition/viewable

<img width="446" alt="screen shot 2016-10-19 at 1 23 24 pm" src="https://cloud.githubusercontent.com/assets/1088217/19517046/3c83d2fe-95ff-11e6-97c4-06aa885c5c9e.png">

https://swift.org/documentation/api-design-guidelines/

<img width="731" alt="screen shot 2016-10-19 at 1 16 53 pm" src="https://cloud.githubusercontent.com/assets/1088217/19516890/7cca5226-95fe-11e6-91af-9998b1eabac5.png">
- Renamed `controllerDelegate` to `controller` and `controllerDataSource` to `dataSource`

They had the `controller` suffix because this was a subclass of `UIPageViewController` which has it's own delegate and dataSource.
