### PR TITLE
Request for thumbnail image when playing videos

### DIFF
--- a/Source/ViewableController.swift
+++ b/Source/ViewableController.swift
@@ -242,8 +242,16 @@ class ViewableController: UIViewController {
                 }
             }
         case .video:
+            let autoplayVideo = self.dataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
+            if !autoplayVideo {
+                viewable.media { image, error in
+                    if let image = image {
+                        self.imageView.image = image
+                    }
+                }
+            }
+
             self.videoView.prepare(using: viewable) {
-                let autoplayVideo = self.dataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
                 if autoplayVideo {
                     self.videoView.play()
                 } else {


### PR DESCRIPTION
For videos before we were using only the placeholder, this PR changes the Viewer so it also asks for the thumbnail. The reason we need this is because the thumbnail can be sometimes a very low res version of the video placeholder and we need to have a way to request for a higher res version of it.