### PR TITLE
Improve failed viewable displaying delegate

### DIFF
--- a/Source/ViewableController.swift
+++ b/Source/ViewableController.swift
@@ -8,7 +8,7 @@ import AVKit
 
 protocol ViewableControllerDelegate: class {
     func viewableControllerDidTapItem(_ viewableController: ViewableController)
-    func viewableController(_ viewableController: ViewableController, didFailPlayingVideoWith error: NSError)
+    func viewableController(_ viewableController: ViewableController, didFailDisplayingVieweableWith error: NSError)
 }
 
 protocol ViewableControllerDataSource: class {
@@ -369,7 +369,7 @@ extension ViewableController: VideoViewDelegate {
 
     func videoViewDidFinishPlaying(_ videoView: VideoView, error: NSError?) {
         if let error = error {
-            self.delegate?.viewableController(self, didFailPlayingVideoWith: error)
+            self.delegate?.viewableController(self, didFailDisplayingVieweableWith: error)
         } else {
             self.repeatButton.alpha = 1
             self.pauseButton.alpha = 0

--- a/Source/ViewerController.swift
+++ b/Source/ViewerController.swift
@@ -1,34 +1,19 @@
 import UIKit
 import CoreData
 
-/**
- The ViewerController takes care of displaying the user's photos/videos in full-screen.
-
- You can swipe right or left to navigate between photos.
- */
-
 public protocol ViewerControllerDataSource: class {
     func numberOfItemsInViewerController(_ viewerController: ViewerController) -> Int
     func viewerController(_ viewerController: ViewerController, viewableAt indexPath: IndexPath) -> Viewable
 }
 
 public protocol ViewerControllerDelegate: class {
-    /**
-     Called when the ViewerController changes focus.
-     */
     func viewerController(_ viewerController: ViewerController, didChangeFocusTo indexPath: IndexPath)
-
-    /**
-     Called when the ViewerController is dismissed.
-     */
     func viewerControllerDidDismiss(_ viewerController: ViewerController)
-
-    /**
-     Called when the video playback fails.
-     */
-    func viewerController(_ viewerController: ViewerController, didFailPlayingVideoAt indexPath: IndexPath, error: NSError)
+    func viewerController(_ viewerController: ViewerController, didFailDisplayingViewableAt indexPath: IndexPath, error: NSError)
 }
 
+
+/// The ViewerController takes care of displaying the user's photos and videos in full-screen. You can swipe right or left to navigate between them.
 public class ViewerController: UIViewController {
     static let domain = "com.bakkenbaeck.Viewer"
     fileprivate static let HeaderHeight = CGFloat(64)
@@ -444,8 +429,8 @@ extension ViewerController: ViewableControllerDelegate {
         self.toggleButtons(self.buttonsAreVisible)
     }
 
-    func viewableController(_ viewableController: ViewableController, didFailPlayingVideoWith error: NSError) {
-        self.delegate?.viewerController(self, didFailPlayingVideoAt: self.currentIndexPath, error: error)
+    func viewableController(_ viewableController: ViewableController, didFailDisplayingVieweableWith error: NSError) {
+        self.delegate?.viewerController(self, didFailDisplayingViewableAt: self.currentIndexPath, error: error)
     }
 }
 


### PR DESCRIPTION
Before we only had a delegate for displaying errors with loading a video, for everything else we were using fatalError.