### PR TITLE
Activate sound when the volume is changed (even in silent mode)

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -28,10 +28,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Activate sound when the volume is changed even if phone is in silent mode (kind of like Snapchat). This is reset when video is closed, so volume must be changed again when new video starts if the user wants sound