### PR TITLE
Stop loading inline video player on tvOS

### DIFF
--- a/Source/ViewableController.swift
+++ b/Source/ViewableController.swift
@@ -248,22 +248,30 @@ class ViewableController: UIViewController {
                 }
             }
         case .video:
-            let autoplayVideo = self.dataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
-            if !autoplayVideo {
+            #if os(iOS)
+                let shouldAutoplayVideo = self.dataSource?.viewableControllerShouldAutoplayVideo(self) ?? false
+                if !shouldAutoplayVideo {
+                    viewable.media { image, _ in
+                        if let image = image {
+                            self.imageView.image = image
+                        }
+                    }
+                }
+
+                self.videoView.prepare(using: viewable) {
+                    if shouldAutoplayVideo {
+                        self.videoView.play()
+                    } else {
+                        self.playButton.alpha = 1
+                    }
+                }
+            #else
                 viewable.media { image, _ in
                     if let image = image {
                         self.imageView.image = image
                     }
                 }
-            }
-
-            self.videoView.prepare(using: viewable) {
-                if autoplayVideo {
-                    self.videoView.play()
-                } else {
-                    self.playButton.alpha = 1
-                }
-            }
+            #endif
         }
     }
 


### PR DESCRIPTION
We have an inline video player for iOS, we are not using this player for tvOS because we have different requirements and we want a native feeling in the tvOS app.

This PR fixes the issue that when a Viewable object becomes focused we were automatically loading the inline player in the background so playback feels faster, we don't need that for the tvOS app, though.